### PR TITLE
fix missing translation for local area in participatory_processes show

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -137,4 +137,5 @@ ignore_unused:
   - decidim.initiatives.pages.home.highlighted_initiatives.*
   - activemodel.attributes.attachment.documents
   - activemodel.attributes.participatory_space_private_user_csv_import.file
+  - decidim.participatory_processes.show.local_area
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,9 @@ en:
           text: What is FranceConnect ?
         forgot_password:
           ok_text: Warning, this password is the one of your local account and in no case the one of the account you use through FranceConnect. It will only be used when you log in with your email address rather than via FranceConnect.
+    participatory_processes:
+      show:
+        local_area: Organization area
     proposals:
       collaborative_drafts:
         edit:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -110,6 +110,9 @@ fr:
           text: Qu'est-ce-que FranceConnect ?
         forgot_password:
           ok_text: Attention, ce mot de passe est celui de votre compte local et en aucun cas celui du compte que vous utilisez au travers de FranceConnect. Il vous servira uniquement lorsque vous vous connecterez avec votre adresse mail plutôt que via FranceConnect.
+    participatory_processes:
+      show:
+        local_area: Espace d'organisation
     proposals:
       collaborative_drafts:
         edit:


### PR DESCRIPTION
🎩 Description
Fix missing translation for local_area in participatory_processes show

📌 Related Issues
[Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=181f0b33244e4710bef8b9054d684fb7&pm=c)
Testing
Go to /admin/participatory_processes/
Edit a participatory_process
Complete the metadata “Espace d’organisation”
Update the participatory process
Click on "voir la page publique" and see on the "Espace d'organisation" instead of "organization area”